### PR TITLE
feat(lint): add restrict-template-expressions

### DIFF
--- a/src/e2e/generate/__snapshots__/prettier.test.ts.snap
+++ b/src/e2e/generate/__snapshots__/prettier.test.ts.snap
@@ -195,6 +195,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {
@@ -317,6 +324,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {
@@ -513,6 +527,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {

--- a/src/e2e/generate/__snapshots__/react.test.ts.snap
+++ b/src/e2e/generate/__snapshots__/react.test.ts.snap
@@ -115,6 +115,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {

--- a/src/e2e/generate/__snapshots__/typescript.test.ts.snap
+++ b/src/e2e/generate/__snapshots__/typescript.test.ts.snap
@@ -121,6 +121,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {

--- a/src/e2e/generate/__snapshots__/vue.test.ts.snap
+++ b/src/e2e/generate/__snapshots__/vue.test.ts.snap
@@ -109,6 +109,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {

--- a/src/e2e/upgrade/__snapshots__/prettier.test.ts.snap
+++ b/src/e2e/upgrade/__snapshots__/prettier.test.ts.snap
@@ -194,7 +194,14 @@ exports[`ESLint Prettier Base Configuration Upgrade Mode should return a typescr
         \\"@typescript-eslint/no-unnecessary-condition\\": \\"error\\",
         \\"@typescript-eslint/no-unnecessary-type-arguments\\": \\"error\\",
         \\"@typescript-eslint/prefer-string-starts-ends-with\\": \\"error\\",
-        \\"@typescript-eslint/switch-exhaustiveness-check\\": \\"error\\"
+        \\"@typescript-eslint/switch-exhaustiveness-check\\": \\"error\\",
+        \\"@typescript-eslint/restrict-template-expressions\\": [
+          \\"error\\",
+          {
+            \\"allowNumber\\": true,
+            \\"allowBoolean\\": true
+          }
+        ]
       }
     }
   ]

--- a/src/e2e/upgrade/__snapshots__/typescript.test.ts.snap
+++ b/src/e2e/upgrade/__snapshots__/typescript.test.ts.snap
@@ -103,7 +103,14 @@ exports[`ESLint Base Configuration Upgrade Mode should return a typescript eslin
         \\"@typescript-eslint/no-unnecessary-condition\\": \\"error\\",
         \\"@typescript-eslint/no-unnecessary-type-arguments\\": \\"error\\",
         \\"@typescript-eslint/prefer-string-starts-ends-with\\": \\"error\\",
-        \\"@typescript-eslint/switch-exhaustiveness-check\\": \\"error\\"
+        \\"@typescript-eslint/switch-exhaustiveness-check\\": \\"error\\",
+        \\"@typescript-eslint/restrict-template-expressions\\": [
+          \\"error\\",
+          {
+            \\"allowNumber\\": true,
+            \\"allowBoolean\\": true
+          }
+        ]
       }
     }
   ]

--- a/src/generator/__tests__/__snapshots__/generate.test.ts.snap
+++ b/src/generator/__tests__/__snapshots__/generate.test.ts.snap
@@ -195,6 +195,13 @@ Object {
         "@typescript-eslint/prefer-nullish-coalescing": "error",
         "@typescript-eslint/prefer-optional-chain": "error",
         "@typescript-eslint/prefer-string-starts-ends-with": "error",
+        "@typescript-eslint/restrict-template-expressions": Array [
+          "error",
+          Object {
+            "allowBoolean": true,
+            "allowNumber": true,
+          },
+        ],
         "@typescript-eslint/strict-boolean-expressions": Array [
           "error",
           Object {

--- a/src/generator/base-configs/typescriptEslintConfig.ts
+++ b/src/generator/base-configs/typescriptEslintConfig.ts
@@ -41,6 +41,14 @@ export const typescriptTypeEslintConfig: Linter.Config = {
     "@typescript-eslint/prefer-string-starts-ends-with": "error",
     // Exhaustiveness checking in switch with union type
     "@typescript-eslint/switch-exhaustiveness-check": "error",
+    // Prevents the text 'undefined' to appear in a template string
+    "@typescript-eslint/restrict-template-expressions": [
+      "error",
+      {
+        allowNumber: true,
+        allowBoolean: true,
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
The goal of this rule is to prevent this from happening: "Hello undefined!" → in this context for instance:

```ts
const hello = `Hello ${user?.name}!`;
```