### PR TITLE
feat: add support for yarn berry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-Clinter
-===
+# Clinter
 
-CLI tool to generate or upgrade linter configurations. 
+CLI tool to generate or upgrade linter configurations.
 
 # Motivation
 
-Every time we start a new projet or join an existing one, it is always struggling to create the perfect linter configuration for the project or upgrade the exisitng one to suit our needs. Another major problem we encounter is how to share configurations between different projects while still acknowledging the differences in tools and frameworks used. This tool attempts to solve these issues by providing an easily extendible and shareable source of truth for all projects.
+Every time we start a new project or join an existing one, it is always struggling to create the perfect linter configuration for the project or upgrade the existing one to suit our needs. Another major problem we encounter is how to share configurations between different projects while still acknowledging the differences in tools and frameworks used. This tool attempts to solve these issues by providing an easily extendible and shareable source of truth for all projects.
 
 # Install
 
@@ -49,7 +48,7 @@ Some use cases require to have the user to manually select which type of project
 
 - Navigate inside your project directory where your ESLint configuration should live (if you need multiple ESLint configurations in different subdirectories, clinter will need to be run in each of the directories)
 - Run Clinter by running `clinter` in the terminal
-- Choose the `manual` option and hit `enter`. You will now have a series of questions to answer to inform Clinter of what type of project you are working on. 
+- Choose the `manual` option and hit `enter`. You will now have a series of questions to answer to inform Clinter of what type of project you are working on.
 
 Clinter will then generate a ESLint configuration matching the provided answers. It will also install and update all required dependencies for the newly updated or generated configuration.
 
@@ -63,7 +62,7 @@ Clinter aims to provide a clear strategy on how to easily and progressively migr
 
 - Add the new ESLint rules to your project configuration (using Clinter or manually by selecting the rules and adding them to the project's ESLint configuration)
 - Run a ESLint pass on your project. You should see a number of errors because of the newly added rules or configuration.
-- Run Clinter with the `disable-errors` option in the project: `clinter --disable-errors`. This command will tell Clinter to add `// eslint-disable-next-line <ESLINT-RULE>` lines inside your codebase where errors are detected. 
+- Run Clinter with the `disable-errors` option in the project: `clinter --disable-errors`. This command will tell Clinter to add `// eslint-disable-next-line <ESLINT-RULE>` lines inside your codebase where errors are detected.
 - Run a ESLint pass again to check if all errors are silenced.
 
 It is now up to the project's developers to progressively align the codebase to the new ESLint rules. This can be done by continuously removing the ignore comments and fixing the underlying issues when coming across them.
@@ -84,7 +83,7 @@ Defaults to the path where the Clinter is run
 
 ### --auto
 
-Boolean: Option to let Clinter automatically infer the ESLint's configuration generator settings. If false, Clinter will ask the option from the user. 
+Boolean: Option to let Clinter automatically infer the ESLint's configuration generator settings. If false, Clinter will ask the option from the user.
 
 Defaults to false.
 

--- a/src/dependencies/dependencies.ts
+++ b/src/dependencies/dependencies.ts
@@ -9,6 +9,10 @@ function installDependenciesYarn(dependencies: string[], dirpath: string): Promi
   return exec(`yarn add --cwd ${dirpath} ${formatDependencies(dependencies)} -D -W`).then(() => Promise.resolve());
 }
 
+function installDependenciesYarnBerry(dependencies: string[], dirpath: string): Promise<void> {
+  return exec(`yarn add --cwd ${dirpath} ${formatDependencies(dependencies)} -D`).then(() => Promise.resolve());
+}
+
 function installDependenciesNpm(dependencies: string[], dirpath: string): Promise<void> {
   return exec(`npm install --prefix ${dirpath} ${formatDependencies(dependencies)} --save-dev`).then(() =>
     Promise.resolve()
@@ -22,5 +26,8 @@ export function installDevDependencies(dependencies: string[], dirPath: string):
 
     case PackageTool.YARN:
       return installDependenciesYarn(dependencies, dirPath);
+
+    case PackageTool.YARN_BERRY:
+      return installDependenciesYarnBerry(dependencies, dirPath);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ async function runUpgradeMode(
   dirPath: string,
   dependenciesConfig: DependenciesConfigObject
 ) {
-  signale.info("Adapting exisiting ESLint configuration ...");
+  signale.info("Adapting existing ESLint configuration ...");
   const existingConfigContainer = findESLintConfigurationFiles(dirPath)[0];
   const eslintConfig = generateEslintConfig(userAnswers, existingConfigContainer.config);
   signale.success("ESLint config generated from previous configuration");
@@ -76,7 +76,7 @@ async function runUpgradeMode(
   if (dependenciesConfig.upgradeDependencies) {
     signale.info("Installing required dependencies ...");
     await installDevDependencies(getConfigDependencies(userAnswers), dirPath);
-    signale.success("All dependencies successfully Installed");
+    signale.success("All dependencies successfully installed");
   } else {
     signale.info("Skipping dependencies upgrade");
   }

--- a/src/parser/package-tool.ts
+++ b/src/parser/package-tool.ts
@@ -4,8 +4,13 @@ import path from "path";
 export enum PackageTool {
   NPM = "NPM",
   YARN = "YARN",
+  YARN_BERRY = "YARN_BERRY",
 }
 
 export function getPackageTool(currentDirPath: string = process.cwd()): PackageTool {
-  return fs.existsSync(path.resolve(currentDirPath, "package-lock.json")) ? PackageTool.NPM : PackageTool.YARN;
+  return fs.existsSync(path.resolve(currentDirPath, "package-lock.json"))
+    ? PackageTool.NPM
+    : fs.existsSync(path.resolve(currentDirPath, ".yarnrc.yml"))
+    ? PackageTool.YARN_BERRY
+    : PackageTool.YARN;
 }

--- a/src/parser/typescript-config.ts
+++ b/src/parser/typescript-config.ts
@@ -2,15 +2,19 @@ import { exec } from "child-process-promise";
 import { getPackageTool, PackageTool } from "parser/package-tool";
 
 const getTSConfigShellString = (dirPath: string, packageTool: PackageTool): string => {
-  if (packageTool === PackageTool.NPM) {
-    return `npx tsc --showConfig -p ${dirPath}`;
-  }
+  switch (packageTool) {
+    case PackageTool.NPM:
+      return `npx tsc --showConfig -p ${dirPath}`;
 
-  if (packageTool === PackageTool.YARN) {
-    return `yarn --silent tsc --showConfig -p ${dirPath}`;
-  }
+    case PackageTool.YARN:
+      return `yarn --silent tsc --showConfig -p ${dirPath}`;
 
-  throw new Error("Unsupported package tool !");
+    case PackageTool.YARN_BERRY:
+      return `yarn tsc --showConfig -p ${dirPath}`;
+
+    default:
+      throw new Error(`Unsupported package tool:  !`);
+  }
 };
 
 const loadTSConfig = async (dirPath: string): Promise<Record<string, any>> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1208,13 +1208,6 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/comment-json@^2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@types/comment-json/-/comment-json-2.4.2.tgz#336368d351b9d29fb08352d37c2686b3fc4d882a"
-  integrity sha512-El8na9x7/3M4KxXvOL34fbXbQtBgETELT89HNL8qK2RTlFpBOjlOSbXp1boODiocSnxWXXLW2WeH3DGazyKkVA==
-  dependencies:
-    comment-json "*"
-
 "@types/eslint@^7.28.0":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.28.0.tgz#7e41f2481d301c68e14f483fe10b017753ce8d5a"
@@ -2331,7 +2324,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comment-json@*, comment-json@^4.1.0:
+comment-json@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/comment-json/-/comment-json-4.1.0.tgz#09d08f0fbc4ad5eeccbac20f469adbb967dcbd2c"
   integrity sha512-WEghmVYaNq9NlWbrkzQTSsya9ycLyxJxpTQfZEan6a5Jomnjw18zS3Podf8q1Zf9BvonvQd/+Z7Z39L7KKzzdQ==


### PR DESCRIPTION
Hello!

I tried to use clinter on a yarn3 project and found that it did not work anymore due to breaking changes in the yarn api when using the `berry` version.

See
- yarn add "classic": https://classic.yarnpkg.com/en/docs/cli/add
- yarn add "berry": https://yarnpkg.com/cli/add

Thanks a lot for this awesome project!